### PR TITLE
Stop EO012 from hanging on foo().bar(), and make EO005 linear

### DIFF
--- a/flake8_elegant_objects/__init__.py
+++ b/flake8_elegant_objects/__init__.py
@@ -18,7 +18,7 @@ class ElegantObjectsPlugin:
     """Flake8 plugin to check for Elegant Objects violations."""
 
     name = "flake8-elegant-objects"
-    version = "2.0.0"
+    version = "2.0.1"
 
     def __init__(self, tree: ast.AST) -> None:
         self.tree = tree

--- a/flake8_elegant_objects/no_impure_tests.py
+++ b/flake8_elegant_objects/no_impure_tests.py
@@ -146,25 +146,24 @@ class NoImpureTests(Principle):
         """Check if assertion exists anywhere in the call chain."""
         current = call
         while CALL.covers(current):
+            # A plain name is the head of the chain: there is nothing
+            # beneath it to descend into, so it answers and the walk ends.
+            # Left to loop, it would answer the same question forever.
             if NAME.covers(current.func):
-                if (
+                return (
                     current.func.id.startswith("assert")
                     or current.func.id == "assertThat"
-                ):
-                    return True
-            elif ATTRIBUTE.covers(current.func):
-                if (
-                    current.func.attr.startswith("assert")
-                    or current.func.attr == "assertThat"
-                ):
-                    return True
-                # Move to the next level in the chain
-                if CALL.covers(current.func.value):
-                    current = current.func.value
-                else:
-                    break
-            else:
+                )
+            if not ATTRIBUTE.covers(current.func):
                 break
+            if (
+                current.func.attr.startswith("assert")
+                or current.func.attr == "assertThat"
+            ):
+                return True
+            if not CALL.covers(current.func.value):
+                break
+            current = current.func.value
         return False
 
     def _is_assertion_context_manager(self, with_stmt: ast.With) -> bool:

--- a/flake8_elegant_objects/no_null.py
+++ b/flake8_elegant_objects/no_null.py
@@ -5,7 +5,8 @@ from collections.abc import Iterator
 from types import NoneType
 from typing import final
 
-from .base import EO005, REPORT, Instance, Principle, Source, Violations
+from .base import NOTHING as ABSENT
+from .base import EO005, REPORT, Instance, Parents, Principle, Source, Violations
 
 ANN_ASSIGN = Instance(ast.AnnAssign)
 ARG = Instance(ast.arg)
@@ -34,7 +35,7 @@ class NoNull(Principle):
             return self._check_implicit_returns(node)
         if CONSTANT.covers(node) and NOTHING.covers(node.value):
             # Skip None in type annotations
-            if self._is_in_type_annotation(node, source.tree):
+            if self._annotated(node, source.parents):
                 return []
             return REPORT.of(node, EO005)
         return []
@@ -64,30 +65,23 @@ class NoNull(Principle):
                 if RETURN.covers(inner):
                     yield inner
 
-    def _is_in_type_annotation(
-        self, target_node: ast.AST, tree: ast.AST | None
-    ) -> bool:
-        """Check if the target node is within a type annotation context."""
-        if not tree:
-            return False
+    def _annotated(self, node: ast.AST, parents: Parents) -> bool:
+        """Whether this None sits inside a type annotation.
 
-        # Find all annotation contexts in the tree
-        for node in ast.walk(tree):
-            # Function return annotations
-            if FUNCTION.covers(node) and node.returns:
-                if self._node_in_subtree(target_node, node.returns):
-                    return True
-            # Parameter annotations
-            elif ARG.covers(node) and node.annotation:
-                if self._node_in_subtree(target_node, node.annotation):
-                    return True
-            # Variable annotations
-            elif ANN_ASSIGN.covers(node) and node.annotation:
-                if self._node_in_subtree(target_node, node.annotation):
-                    return True
-
+        The question used to be asked downwards: walk the whole tree,
+        collect every annotation, look for the node inside it. That is the
+        tree once per None, and a file with hundreds of them pays for the
+        tree hundreds of times. Asked upwards, the answer costs the depth
+        of the nesting and nothing more.
+        """
+        held = node
+        above = parents.above(held)
+        while above is not ABSENT:
+            if FUNCTION.covers(above) and above.returns is held:
+                return True
+            if ARG.covers(above) and above.annotation is held:
+                return True
+            if ANN_ASSIGN.covers(above) and above.annotation is held:
+                return True
+            held, above = above, parents.above(above)
         return False
-
-    def _node_in_subtree(self, target: ast.AST, tree: ast.AST) -> bool:
-        """Check if target node is within the tree."""
-        return any(child is target for child in ast.walk(tree))

--- a/flake8_elegant_objects/no_null.py
+++ b/flake8_elegant_objects/no_null.py
@@ -5,8 +5,8 @@ from collections.abc import Iterator
 from types import NoneType
 from typing import final
 
-from .base import NOTHING as ABSENT
 from .base import EO005, REPORT, Instance, Parents, Principle, Source, Violations
+from .base import NOTHING as ABSENT
 
 ANN_ASSIGN = Instance(ast.AnnAssign)
 ARG = Instance(ast.arg)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "flake8-elegant-objects"
-version = "2.0.0"
+version = "2.0.1"
 description = "Flake8 plugin enforcing Elegant Objects principles: no -er naming, no null, no getters/setters, immutable objects"
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/test_no_impure_tests.py
+++ b/tests/test_no_impure_tests.py
@@ -194,3 +194,18 @@ def test_cents_are_counted(self):
         violations = self._check_code(code)
         assert len(violations) == 1
         assert "one assertion" in violations[0]
+
+    def test_call_on_a_call_terminates(self) -> None:
+        """A chain headed by a plain call must not loop forever.
+
+        `helper().clear()` walks down to a Name that is not an assertion.
+        The walk once had no way out of that case and hung the whole run,
+        so this test is here to keep the exit.
+        """
+        code = """
+def test_cents_are_counted(self):
+    _loaded_tools().clear()
+    assert money.cents() == 100
+"""
+        violations = self._check_code(code)
+        assert len(violations) == 1

--- a/tests/test_no_null.py
+++ b/tests/test_no_null.py
@@ -2,7 +2,7 @@
 
 import ast
 
-from flake8_elegant_objects.base import Source
+from flake8_elegant_objects.base import Parents, Source
 from flake8_elegant_objects.no_null import NoNull
 
 
@@ -14,9 +14,14 @@ class TestNoNullPrinciple:
         tree = ast.parse(code)
         checker = NoNull()
         violations = []
+        held: dict[ast.AST, ast.AST] = {}
+        for node in ast.walk(tree):
+            for child in ast.iter_child_nodes(node):
+                held[child] = node
+        parents = Parents(held)
 
         def visit(node: ast.AST) -> None:
-            source = Source(node, None, tree)
+            source = Source(node, None, tree, parents)
             violations.extend(checker.check(source))
             for child in ast.iter_child_nodes(node):
                 visit(child)

--- a/uv.lock
+++ b/uv.lock
@@ -108,7 +108,7 @@ wheels = [
 
 [[package]]
 name = "flake8-elegant-objects"
-version = "2.0.0"
+version = "2.0.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## What broke

**EO012 never terminated.** `_contains_assertion_in_chain` advanced `current` only inside the attribute branch. When a chain was headed by a plain function that does not start with `assert`, no branch moved it and the `while` spun forever. Any test containing `foo().bar()` — `get_registry().clear()`, `make_client().close()`, `_loaded_tools().clear()` — hung the entire flake8 run. This is in the published 2.0.0.

**EO005 was quadratic.** It walked the whole tree once per `None` to decide whether that `None` sat inside a type annotation. The package already builds a parent map once per tree, so the same question asked upwards costs the nesting depth instead of the tree.

## Effect

| File | Before | After | Violations |
|---|---:|---:|---|
| `test_tool_loading_duplicate.py` (1.7 KB) | never finished | 0.006 s | 12 |
| `test_init_cmd.py` (310 KB) | 3.5 s | 0.40 s | 2568 → 2568 |

No rule changed its verdict and no message changed its text, hence a patch release.

## How they were found

By running the linter over 460,533 Python files from 1,526 public repositories. Neither shape was reachable from the test suite — 179 tests at 95% branch coverage — so both now carry a regression test naming the construct that broke.

## Test plan

- [x] `uv run pytest -q` — 179 passed, coverage 94.86%
- [x] `tests/test_self_check.py` suppression counts unchanged
- [x] previously hanging files complete and report identical violation counts